### PR TITLE
New Feature, insert input-group in controls

### DIFF
--- a/src/AdamWathan/BootForms/Elements/FormGroup.php
+++ b/src/AdamWathan/BootForms/Elements/FormGroup.php
@@ -8,6 +8,7 @@ class FormGroup extends Element
 	protected $label;
 	protected $control;
 	protected $helpBlock;
+	protected $inputGroup;
 
 	public function __construct(Label $label, Element $control)
 	{
@@ -21,13 +22,30 @@ class FormGroup extends Element
 		$html  = '<div';
 		$html .= $this->renderAttributes();
 		$html .= '>';
-		$html .=  $this->label;
-		$html .=  $this->control;
+		$html .= $this->label;
+		$html .= $this->renderInputGroup();
 		$html .= $this->renderHelpBlock();
-
 		$html .= '</div>';
 
 		return $html;
+	}
+
+	public function inputGroup($class = "")
+	{
+		if (!isset($this->inputGroup)) {
+			$this->inputGroup = new InputGroup($this, $class);
+		}
+
+		return $this->inputGroup;
+	}
+
+	protected function renderInputGroup()
+	{
+		if ($this->inputGroup) {
+			return $this->inputGroup->render();
+		}
+
+		return $this->control;
 	}
 
 	public function helpBlock($text)

--- a/src/AdamWathan/BootForms/Elements/GroupWrapper.php
+++ b/src/AdamWathan/BootForms/Elements/GroupWrapper.php
@@ -22,6 +22,11 @@ class GroupWrapper
 		return $this;
 	}
 
+	public function inputGroup($class = "")
+	{
+		return $this->formGroup->inputGroup($class);
+	}
+
 	public function __toString()
 	{
 		return $this->render();

--- a/src/AdamWathan/BootForms/Elements/InputGroup.php
+++ b/src/AdamWathan/BootForms/Elements/InputGroup.php
@@ -1,0 +1,55 @@
+<?php namespace AdamWathan\BootForms\Elements;
+
+use AdamWathan\Form\Elements\Element;
+use AdamWathan\BootForms\Elements\FormGroup;
+
+class InputGroup extends Element
+{
+	private $formGroup;
+	private $beforeAddon = array();
+	private $afterAddon = array();
+
+	public function __construct(FormGroup $formGroup, $class = '')
+	{
+		$this->formGroup = $formGroup;
+		$this->addClass('input-group');
+		if (!empty($class)) $this->addClass($class);
+	}
+
+	public function beforeAddon($addon)
+	{
+		$this->beforeAddon[] = $addon;
+		return $this->formGroup;
+	}
+
+	public function afterAddon($addon)
+	{
+		$this->afterAddon[] = $addon;
+		return $this->formGroup;
+	}
+
+	protected function renderAddons($addons)
+	{
+		$html = '';
+		foreach ($addons as $addon) {
+			$html .= '<span class="input-group-addon">';
+			$html .= $addon;
+			$html .= '</span>';
+		}
+
+		return $html;
+	}
+
+	public function render()
+	{
+		$html = '<div';
+		$html .= $this->renderAttributes();
+		$html .= '>';
+		$html .= $this->renderAddons($this->beforeAddon);
+		$html .= $this->formGroup->control();
+		$html .= $this->renderAddons($this->afterAddon);
+		$html .= '</div>';
+		
+		return $html;
+	}
+}

--- a/tests/BasicFormBuilderTest.php
+++ b/tests/BasicFormBuilderTest.php
@@ -59,6 +59,13 @@ class BasicFormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($expected, $result);
 	}
 
+	public function testRenderTextGroupWithInputGroup()
+	{
+		$expected = '<div class="form-group"><label class="control-label" for="email">Email</label><div class="input-group"><span class="input-group-addon">@</span><input type="text" name="email" id="email" class="form-control"></div></div>';
+		$result = $this->form->text('Email', 'email')->inputGroup()->beforeAddon('@')->render();
+		$this->assertEquals($expected, $result);
+	}
+
 	public function testRenderTextGroupWithOldInput()
 	{
 		$oldInput = Mockery::mock('AdamWathan\Form\OldInput\OldInputInterface');

--- a/tests/FormGroupTest.php
+++ b/tests/FormGroupTest.php
@@ -81,4 +81,16 @@ class FormGroupTest extends PHPUnit_Framework_TestCase
         $result = $formGroup->render();
         $this->assertEquals($expected, $result);
     }
+
+    public function testCanRenderWithInputGroup()
+    {
+        $label = $this->builder->label('Site');
+        $text = $this->builder->text('site');
+        $formGroup = new FormGroup($label, $text);
+        $formGroup->inputGroup()->beforeAddon('www')->inputGroup()->afterAddon('.com.br');
+
+        $expected = '<div class="form-group"><label>Site</label><div class="input-group"><span class="input-group-addon">www</span><input type="text" name="site"><span class="input-group-addon">.com.br</span></div></div>';
+        $result = $formGroup->render();
+        $this->assertEquals($expected, $result);
+    }
 }

--- a/tests/InputGroupTest.php
+++ b/tests/InputGroupTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use Mockery as m;
+use AdamWathan\BootForms\Elements\InputGroup;
+
+class InputGroupTest extends PHPUnit_Framework_TestCase
+{
+	public function setUp()
+	{
+	}
+
+	public function testCanRenderBeforeAddon()
+	{
+		$control = '<input type="text" name="username">';
+		$formGroup = m::mock('AdamWathan\BootForms\Elements\FormGroup');
+		$formGroup->shouldReceive('control')->once()->andReturn($control);
+		
+		$inputGroup = new InputGroup($formGroup, 'input-group-lg');
+		$this->assertEquals($formGroup, $inputGroup->beforeAddon('@'));
+		
+		$expected = '<div class="input-group input-group-lg"><span class="input-group-addon">@</span>'.$control.'</div>';
+		$result = $inputGroup->render();
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testCanRenderAfterAddon()
+	{
+		$control = '<input type="text" name="username">';
+		$formGroup = m::mock('AdamWathan\BootForms\Elements\FormGroup');
+		$formGroup->shouldReceive('control')->once()->andReturn($control);
+		
+		$inputGroup = new InputGroup($formGroup, 'input-group-lg');
+		$this->assertEquals($formGroup, $inputGroup->afterAddon(',00'));
+		
+		$expected = '<div class="input-group input-group-lg">'.$control.'<span class="input-group-addon">,00</span></div>';
+		$result = $inputGroup->render();
+		$this->assertEquals($expected, $result);
+	}
+}


### PR DESCRIPTION
- Created element InputGroup
- Add method inputGroup in class FormGroup and GroupWrapper
#### Usage

```
BootForm::text('Username', 'username')->inputGroup()->beforeAddon('@')

BootForm::text('Site', 'site')->inputGroup()->afterAddon('.com.br')
```
