### PR TITLE
Allow specifying checked state of inline checkboxes

### DIFF
--- a/src/AdamWathan/BootForms/BasicFormBuilder.php
+++ b/src/AdamWathan/BootForms/BasicFormBuilder.php
@@ -116,10 +116,16 @@ class BasicFormBuilder
 		return $this->formGroup($label, $name, $control);
 	}
 
-	public function inlineCheckbox($label, $name)
+	public function inlineCheckbox($label, $name, $checked = false)
 	{
 		$label = $this->builder->label($label)->addClass('checkbox-inline');
 		$control = $this->builder->checkbox($name);
+
+		if ($checked) {
+			$control->check();
+		} else {
+			$control->uncheck();
+		}
 
 		return $label->after($control);
 	}


### PR DESCRIPTION
At the moment, because the label is returned, we have no way of chaining the `check()` or `uncheck()` calls. Passing in a param to check or uncheck solves this. Defaults to `false`, so it doesn't break any existing calls, and since that's the default behaviour anyway at the moment.
