### PR TITLE
Fix return of method Form Group Horizontal for GroupWrapper

### DIFF
--- a/src/AdamWathan/BootForms/HorizontalFormBuilder.php
+++ b/src/AdamWathan/BootForms/HorizontalFormBuilder.php
@@ -53,7 +53,7 @@ class HorizontalFormBuilder extends BasicFormBuilder
 			$formGroup->addClass('has-error');
 		}
 
-		return $formGroup;
+		return $this->wrap($formGroup);
 	}
 
 	protected function getLabelClass()


### PR DESCRIPTION
The horizontal form was returning the "form group" direct. 
Thus it was not possible to change the attributes of the control. 

``` php
BootForm::text('Name', 'name')->attribute('maxlength', '50 ')
```
