### PR TITLE
Support configurable column sizes at different breakpoints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
 

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.4.0",
         "adamwathan/form": "~0.4"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",
-        "mockery/mockery": "dev-master@dev",
+        "mockery/mockery": "0.9.*",
         "codeclimate/php-test-reporter": "0.1.*"
     },
     "autoload": {

--- a/readme.md
+++ b/readme.md
@@ -175,15 +175,18 @@ And reduces it to this:
 
 ### Horizontal Forms
 
-To use a horizontal form instead of the standard basic form, simply swap the `BootForm::open()` call:
+To use a horizontal form instead of the standard basic form, simply swap the `BootForm::open()` call with a call to `openHorizontal($columnSizes)` instead:
 
 ```php
 
 // Width in columns of the left and right side
-$labelWidth = 2;
-$controlWidth = 10;
+// for each breakpoint you'd like to specify.
+$columnSizes = [
+  'sm' => [4, 8],
+  'lg' => [2, 10]
+];
 
-{!! BootForm::openHorizontal($labelWidth, $controlWidth) !!}
+{!! BootForm::openHorizontal($columnSizes) !!}
   {!! BootForm::text('First Name', 'first_name') !!}
   {!! BootForm::text('Last Name', 'last_name') !!}
   {!! BootForm::text('Date of Birth', 'date_of_birth') !!}

--- a/src/AdamWathan/BootForms/BootForm.php
+++ b/src/AdamWathan/BootForms/BootForm.php
@@ -14,17 +14,15 @@ class BootForm
 		$this->horizontalFormBuilder = $horizontalFormBuilder;
 	}
 
-
 	public function open()
 	{
 		$this->builder = $this->basicFormBuilder;
 		return $this->builder->open();
 	}
 
-	public function openHorizontal($labelWidth, $controlWidth)
+	public function openHorizontal($columnSizes)
 	{
-		$this->horizontalFormBuilder->setLabelWidth($labelWidth);
-		$this->horizontalFormBuilder->setControlWidth($controlWidth);
+		$this->horizontalFormBuilder->setColumnSizes($columnSizes);
 		$this->builder = $this->horizontalFormBuilder;
 		return $this->builder->open();
 	}

--- a/src/AdamWathan/BootForms/Elements/HorizontalFormGroup.php
+++ b/src/AdamWathan/BootForms/Elements/HorizontalFormGroup.php
@@ -5,16 +5,16 @@ use AdamWathan\Form\Elements\Label;
 
 class HorizontalFormGroup extends FormGroup
 {
-	protected $controlWidth;
+	protected $controlSizes;
 
-	public function __construct(Label $label, Element $control, $controlWidth = 10)
+	public function __construct(Label $label, Element $control, $controlSizes = ['lg' => 10])
 	{
 		parent::__construct($label, $control);
-		$this->controlWidth = $controlWidth;
+		$this->controlSizes = $controlSizes;
 	}
 
 	public function render()
-	{		
+	{
 		$html  = '<div';
 		$html .= $this->renderAttributes();
 		$html .= '>';
@@ -37,7 +37,7 @@ class HorizontalFormGroup extends FormGroup
 
 	protected function getControlClass()
 	{
-		return 'col-lg-' . $this->controlWidth;
+		return 'col-lg-' . $this->controlSizes['lg'];
 	}
 
 	public function __call($method, $parameters)

--- a/src/AdamWathan/BootForms/Elements/HorizontalFormGroup.php
+++ b/src/AdamWathan/BootForms/Elements/HorizontalFormGroup.php
@@ -7,7 +7,7 @@ class HorizontalFormGroup extends FormGroup
 {
 	protected $controlSizes;
 
-	public function __construct(Label $label, Element $control, $controlSizes = ['lg' => 10])
+	public function __construct(Label $label, Element $control, $controlSizes)
 	{
 		parent::__construct($label, $control);
 		$this->controlSizes = $controlSizes;
@@ -37,7 +37,11 @@ class HorizontalFormGroup extends FormGroup
 
 	protected function getControlClass()
 	{
-		return 'col-lg-' . $this->controlSizes['lg'];
+		$class = '';
+		foreach ($this->controlSizes as $breakpoint => $size) {
+			$class .= sprintf('col-%s-%s ', $breakpoint, $size);
+		}
+		return trim($class);
 	}
 
 	public function __call($method, $parameters)

--- a/src/AdamWathan/BootForms/Elements/OffsetFormGroup.php
+++ b/src/AdamWathan/BootForms/Elements/OffsetFormGroup.php
@@ -37,8 +37,13 @@ class OffsetFormGroup extends Element
 
 	protected function getControlClass()
 	{
-		$offset = 12 - $this->columnSizes['lg'][1];
-		return 'col-lg-offset-' . $offset . ' col-lg-' . $this->columnSizes['lg'][1];
+		$class = '';
+		foreach ($this->columnSizes as $breakpoint => $sizes) {
+			$offset = 12 - $sizes[1];
+			$class .= sprintf('col-%s-offset-%s col-%s-%s ', $breakpoint, $offset, $breakpoint, $sizes[1]);
+		}
+		return trim($class);
+
 	}
 
 	public function __call($method, $parameters)

--- a/src/AdamWathan/BootForms/Elements/OffsetFormGroup.php
+++ b/src/AdamWathan/BootForms/Elements/OffsetFormGroup.php
@@ -6,17 +6,17 @@ use AdamWathan\Form\Elements\Label;
 class OffsetFormGroup extends Element
 {
 	protected $control;
-	protected $controlWidth;
+	protected $columnSizes;
 
-	public function __construct(Element $control, $controlWidth = 10)
+	public function __construct(Element $control, $columnSizes)
 	{
 		$this->control = $control;
-		$this->controlWidth = $controlWidth;
+		$this->columnSizes = $columnSizes;
 		$this->addClass('form-group');
 	}
 
 	public function render()
-	{		
+	{
 		$html  = '<div';
 		$html .= $this->renderAttributes();
 		$html .= '>';
@@ -29,16 +29,16 @@ class OffsetFormGroup extends Element
 		return $html;
 	}
 
-	public function setControlWidth($width)
+	public function setColumnSizes($columnSizes)
 	{
-		$this->controlWidth = $width;
+		$this->columnSizes = $columnSizes;
 		return $this;
 	}
 
 	protected function getControlClass()
 	{
-		$offset = 12 - $this->controlWidth;
-		return 'col-lg-offset-' . $offset . ' col-lg-' . $this->controlWidth;
+		$offset = 12 - $this->columnSizes['lg'][1];
+		return 'col-lg-offset-' . $offset . ' col-lg-' . $this->columnSizes['lg'][1];
 	}
 
 	public function __call($method, $parameters)

--- a/src/AdamWathan/BootForms/HorizontalFormBuilder.php
+++ b/src/AdamWathan/BootForms/HorizontalFormBuilder.php
@@ -59,7 +59,11 @@ class HorizontalFormBuilder extends BasicFormBuilder
 
 	protected function getLabelClass()
 	{
-		return 'col-lg-' . $this->columnSizes['lg'][0];
+		$class = '';
+		foreach ($this->columnSizes as $breakpoint => $sizes) {
+			$class .= sprintf('col-%s-%s ', $breakpoint, $sizes[0]);
+		}
+		return trim($class);
 	}
 
 	public function button($value, $name = null, $type = "btn-default")

--- a/src/AdamWathan/BootForms/HorizontalFormBuilder.php
+++ b/src/AdamWathan/BootForms/HorizontalFormBuilder.php
@@ -8,27 +8,19 @@ use AdamWathan\BootForms\Elements\HelpBlock;
 
 class HorizontalFormBuilder extends BasicFormBuilder
 {
-	private $labelWidth;
-	private $controlWidth;
+	private $columnSizes;
 
 	protected $builder;
 
-	public function __construct(FormBuilder $builder)
+	public function __construct(FormBuilder $builder, $columnSizes = ['lg' => [2, 10]])
 	{
 		$this->builder = $builder;
-		$this->labelWidth = 2;
-		$this->controlWidth = 10;
+		$this->columnSizes = $columnSizes;
 	}
 
-	public function setLabelWidth($width)
+	public function setColumnSizes($columnSizes)
 	{
-		$this->labelWidth = $width;
-		return $this;
-	}
-
-	public function setControlWidth($width)
-	{
-		$this->controlWidth = $width;
+		$this->columnSizes = $columnSizes;
 		return $this;
 	}
 
@@ -46,7 +38,7 @@ class HorizontalFormBuilder extends BasicFormBuilder
 
 		$control->id($name)->addClass('form-control');
 
-		$formGroup = new HorizontalFormGroup($label, $control, $this->controlWidth);
+		$formGroup = new HorizontalFormGroup($label, $control, $this->getControlSizes());
 
 		if ($this->builder->hasError($name)) {
 			$formGroup->helpBlock($this->builder->getError($name));
@@ -56,21 +48,30 @@ class HorizontalFormBuilder extends BasicFormBuilder
 		return $this->wrap($formGroup);
 	}
 
+	protected function getControlSizes()
+	{
+		$controlSizes = [];
+		foreach ($this->columnSizes as $breakpoint => $sizes) {
+			$controlSizes[$breakpoint] = $sizes[1];
+		}
+		return $controlSizes;
+	}
+
 	protected function getLabelClass()
 	{
-		return 'col-lg-' . $this->labelWidth;
+		return 'col-lg-' . $this->columnSizes['lg'][0];
 	}
 
 	public function button($value, $name = null, $type = "btn-default")
 	{
 		$button = $this->builder->button($value, $name)->addClass('btn')->addClass($type);
-		return new OffsetFormGroup($button, $this->controlWidth);
+		return new OffsetFormGroup($button, $this->columnSizes);
 	}
 
 	public function submit($value = "Submit", $type = "btn-default")
 	{
 		$button = $this->builder->submit($value)->addClass('btn')->addClass($type);
-		return new OffsetFormGroup($button, $this->controlWidth);
+		return new OffsetFormGroup($button, $this->columnSizes);
 	}
 
 	public function checkbox($label, $name)
@@ -78,7 +79,7 @@ class HorizontalFormBuilder extends BasicFormBuilder
 		$control = $this->builder->checkbox($name);
 		$checkGroup = $this->checkGroup($label, $name, $control)->addClass('checkbox');
 
-		return new OffsetFormGroup($checkGroup, $this->controlWidth);
+		return new OffsetFormGroup($checkGroup, $this->columnSizes);
 	}
 
 	protected function checkGroup($label, $name, $control)
@@ -104,7 +105,7 @@ class HorizontalFormBuilder extends BasicFormBuilder
 		$control = $this->builder->radio($name, $value);
 		$checkGroup = $this->checkGroup($label, $name, $control)->addClass('radio');
 
-		return new OffsetFormGroup($checkGroup, $this->controlWidth);
+		return new OffsetFormGroup($checkGroup, $this->columnSizes);
 	}
 
 	public function file($label, $name, $value = null)
@@ -117,7 +118,7 @@ class HorizontalFormBuilder extends BasicFormBuilder
 
 		$control->id($name);
 
-		$formGroup = new HorizontalFormGroup($label, $control, $this->controlWidth);
+		$formGroup = new HorizontalFormGroup($label, $control, $this->getControlSizes());
 
 		if ($this->builder->hasError($name)) {
 			$formGroup->helpBlock($this->builder->getError($name));

--- a/tests/HorizontalFormBuilderTest.php
+++ b/tests/HorizontalFormBuilderTest.php
@@ -56,7 +56,7 @@ class HorizontalFormBuilderTest extends PHPUnit_Framework_TestCase
 
 	public function testRenderTextGroupWithCustomWidths()
 	{
-		$this->form->setLabelWidth(3)->setControlWidth(9);
+		$this->form->setColumnSizes(['lg' => [3, 9]]);
 		$expected = '<div class="form-group"><label class="col-lg-3 control-label" for="email">Email</label><div class="col-lg-9"><input type="text" name="email" id="email" class="form-control"></div></div>';
 		$result = $this->form->text('Email', 'email')->render();
 		$this->assertEquals($expected, $result);

--- a/tests/HorizontalFormBuilderTest.php
+++ b/tests/HorizontalFormBuilderTest.php
@@ -62,6 +62,14 @@ class HorizontalFormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($expected, $result);
 	}
 
+	public function testRenderTextGroupWithMultipleBreakpointSizes()
+	{
+		$this->form->setColumnSizes(['xs' => [5, 7], 'lg' => [3, 9]]);
+		$expected = '<div class="form-group"><label class="col-xs-5 col-lg-3 control-label" for="email">Email</label><div class="col-xs-7 col-lg-9"><input type="text" name="email" id="email" class="form-control"></div></div>';
+		$result = $this->form->text('Email', 'email')->render();
+		$this->assertEquals($expected, $result);
+	}
+
 	public function testRenderTextGroupWithValue()
 	{
 		$expected = '<div class="form-group"><label class="col-lg-2 control-label" for="email">Email</label><div class="col-lg-10"><input type="text" name="email" id="email" class="form-control" value="example@example.com"></div></div>';
@@ -177,6 +185,22 @@ class HorizontalFormBuilderTest extends PHPUnit_Framework_TestCase
 	public function testRenderButton()
 	{
 		$expected = '<div class="form-group"><div class="col-lg-offset-2 col-lg-10"><button type="button" class="btn btn-default">Click Me</button></div></div>';
+		$result = $this->form->button('Click Me')->render();
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testRenderButtonWithCustomColumnSizes()
+	{
+		$this->form->setColumnSizes(['lg' => [3, 9]]);
+		$expected = '<div class="form-group"><div class="col-lg-offset-3 col-lg-9"><button type="button" class="btn btn-default">Click Me</button></div></div>';
+		$result = $this->form->button('Click Me')->render();
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testRenderButtonWithMultipleBreakpointSizes()
+	{
+		$this->form->setColumnSizes(['xs' => [5, 7], 'lg' => [3, 9]]);
+		$expected = '<div class="form-group"><div class="col-xs-offset-5 col-xs-7 col-lg-offset-3 col-lg-9"><button type="button" class="btn btn-default">Click Me</button></div></div>';
 		$result = $this->form->button('Click Me')->render();
 		$this->assertEquals($expected, $result);
 	}

--- a/tests/HorizontalFormBuilderTest.php
+++ b/tests/HorizontalFormBuilderTest.php
@@ -56,7 +56,7 @@ class HorizontalFormBuilderTest extends PHPUnit_Framework_TestCase
 
 	public function testRenderTextGroupWithCustomWidths()
 	{
-		$this->form->setColumnSizes(['lg' => [3, 9]]);
+		$this->form->setColumnSizes(array('lg' => array(3, 9)));
 		$expected = '<div class="form-group"><label class="col-lg-3 control-label" for="email">Email</label><div class="col-lg-9"><input type="text" name="email" id="email" class="form-control"></div></div>';
 		$result = $this->form->text('Email', 'email')->render();
 		$this->assertEquals($expected, $result);
@@ -64,7 +64,7 @@ class HorizontalFormBuilderTest extends PHPUnit_Framework_TestCase
 
 	public function testRenderTextGroupWithMultipleBreakpointSizes()
 	{
-		$this->form->setColumnSizes(['xs' => [5, 7], 'lg' => [3, 9]]);
+		$this->form->setColumnSizes(array('xs' => array(5, 7), 'lg' => array(3, 9)));
 		$expected = '<div class="form-group"><label class="col-xs-5 col-lg-3 control-label" for="email">Email</label><div class="col-xs-7 col-lg-9"><input type="text" name="email" id="email" class="form-control"></div></div>';
 		$result = $this->form->text('Email', 'email')->render();
 		$this->assertEquals($expected, $result);
@@ -191,7 +191,7 @@ class HorizontalFormBuilderTest extends PHPUnit_Framework_TestCase
 
 	public function testRenderButtonWithCustomColumnSizes()
 	{
-		$this->form->setColumnSizes(['lg' => [3, 9]]);
+		$this->form->setColumnSizes(array('lg' => array(3, 9)));
 		$expected = '<div class="form-group"><div class="col-lg-offset-3 col-lg-9"><button type="button" class="btn btn-default">Click Me</button></div></div>';
 		$result = $this->form->button('Click Me')->render();
 		$this->assertEquals($expected, $result);
@@ -199,7 +199,7 @@ class HorizontalFormBuilderTest extends PHPUnit_Framework_TestCase
 
 	public function testRenderButtonWithMultipleBreakpointSizes()
 	{
-		$this->form->setColumnSizes(['xs' => [5, 7], 'lg' => [3, 9]]);
+		$this->form->setColumnSizes(array('xs' => array(5, 7), 'lg' => array(3, 9)));
 		$expected = '<div class="form-group"><div class="col-xs-offset-5 col-xs-7 col-lg-offset-3 col-lg-9"><button type="button" class="btn btn-default">Click Me</button></div></div>';
 		$result = $this->form->button('Click Me')->render();
 		$this->assertEquals($expected, $result);


### PR DESCRIPTION
This introduces a breaking change to the `openHorizontal()` method. It now takes an associative array mapping breakpoints to pairs of column sizes, instead of just a left/right column size like before. Previously, those values were being hard coded to the `lg` breakpoint.

To simulate the old behavior, change this:

`BootForm::openHorizontal(3, 9)`

...to this:

`BootForm::openHorizontal(['lg' => [3, 9]]);`