### PR TITLE
Remove render() calls from API tests.

### DIFF
--- a/tests/BasicFormBuilderTest.php
+++ b/tests/BasicFormBuilderTest.php
@@ -22,14 +22,14 @@ class BasicFormBuilderTest extends PHPUnit_Framework_TestCase
 	public function testRenderTextGroup()
 	{
 		$expected = '<div class="form-group"><label class="control-label" for="email">Email</label><input type="text" name="email" id="email" class="form-control"></div>';
-		$result = $this->form->text('Email', 'email')->render();
+		$result = $this->form->text('Email', 'email');
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testRenderTextGroupWithValue()
 	{
 		$expected = '<div class="form-group"><label class="control-label" for="email">Email</label><input type="text" name="email" id="email" class="form-control" value="example@example.com"></div>';
-		$result = $this->form->text('Email', 'email')->value('example@example.com')->render();
+		$result = $this->form->text('Email', 'email')->value('example@example.com');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -42,7 +42,7 @@ class BasicFormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->builder->setErrorStore($errorStore);
 
 		$expected = '<div class="form-group has-error"><label class="control-label" for="email">Email</label><input type="text" name="email" id="email" class="form-control"><p class="help-block">Email is required.</p></div>';
-		$result = $this->form->text('Email', 'email')->render();
+		$result = $this->form->text('Email', 'email');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -55,7 +55,7 @@ class BasicFormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->builder->setErrorStore($errorStore);
 
 		$expected = '<div class="form-group has-error"><label class="control-label" for="email">Email</label><input type="text" name="email" id="email" class="form-control"><p class="help-block">Email is required.</p></div>';
-		$result = $this->form->text('Email', 'email')->helpBlock('some custom text')->render();
+		$result = $this->form->text('Email', 'email')->helpBlock('some custom text');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -68,7 +68,7 @@ class BasicFormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->builder->setOldInputProvider($oldInput);
 
 		$expected = '<div class="form-group"><label class="control-label" for="email">Email</label><input type="text" name="email" value="example@example.com" id="email" class="form-control"></div>';
-		$result = $this->form->text('Email', 'email')->render();
+		$result = $this->form->text('Email', 'email');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -81,14 +81,14 @@ class BasicFormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->builder->setOldInputProvider($oldInput);
 
 		$expected = '<div class="form-group"><label class="control-label" for="email">Email</label><input type="text" name="email" value="example@example.com" id="email" class="form-control"></div>';
-		$result = $this->form->text('Email', 'email')->defaultValue('test@test.com')->render();
+		$result = $this->form->text('Email', 'email')->defaultValue('test@test.com');
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testRenderTextGroupWithDefaultValue()
 	{
 		$expected = '<div class="form-group"><label class="control-label" for="email">Email</label><input type="text" name="email" id="email" class="form-control" value="test@test.com"></div>';
-		$result = $this->form->text('Email', 'email')->defaultValue('test@test.com')->render();
+		$result = $this->form->text('Email', 'email')->defaultValue('test@test.com');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -107,14 +107,14 @@ class BasicFormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->builder->setErrorStore($errorStore);
 
 		$expected = '<div class="form-group has-error"><label class="control-label" for="email">Email</label><input type="text" name="email" value="example@example.com" id="email" class="form-control"><p class="help-block">Email is required.</p></div>';
-		$result = $this->form->text('Email', 'email')->render();
+		$result = $this->form->text('Email', 'email');
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testRenderPasswordGroup()
 	{
 		$expected = '<div class="form-group"><label class="control-label" for="password">Password</label><input type="password" name="password" id="password" class="form-control"></div>';
-		$result = $this->form->password('Password', 'password')->render();
+		$result = $this->form->password('Password', 'password');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -127,7 +127,7 @@ class BasicFormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->builder->setOldInputProvider($oldInput);
 
 		$expected = '<div class="form-group"><label class="control-label" for="password">Password</label><input type="password" name="password" id="password" class="form-control"></div>';
-		$result = $this->form->password('Password', 'password')->render();
+		$result = $this->form->password('Password', 'password');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -140,42 +140,42 @@ class BasicFormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->builder->setErrorStore($errorStore);
 
 		$expected = '<div class="form-group has-error"><label class="control-label" for="password">Password</label><input type="password" name="password" id="password" class="form-control"><p class="help-block">Password is required.</p></div>';
-		$result = $this->form->password('Password', 'password')->render();
+		$result = $this->form->password('Password', 'password');
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testRenderButton()
 	{
 		$expected = '<button type="button" class="btn btn-default">Click Me</button>';
-		$result = $this->form->button('Click Me')->render();
+		$result = $this->form->button('Click Me');
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testRenderButtonWithNameAndAlternateStyling()
 	{
 		$expected = '<button type="button" name="success" class="btn btn-success">Click Me</button>';
-		$result = $this->form->button('Click Me', 'success', 'btn-success')->render();
+		$result = $this->form->button('Click Me', 'success', 'btn-success');
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testRenderSubmit()
 	{
 		$expected = '<button type="submit" class="btn btn-default">Submit</button>';
-		$result = $this->form->submit()->render();
+		$result = $this->form->submit();
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testRenderSubmitWithAlternateStyling()
 	{
 		$expected = '<button type="submit" class="btn btn-success">Submit</button>';
-		$result = $this->form->submit('Submit', 'btn-success')->render();
+		$result = $this->form->submit('Submit', 'btn-success');
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testRenderSubmitWithValue()
 	{
 		$expected = '<button type="submit" class="btn btn-success">Sign Up</button>';
-		$result = $this->form->submit('Sign Up', 'btn-success')->render();
+		$result = $this->form->submit('Sign Up', 'btn-success');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -184,7 +184,7 @@ class BasicFormBuilderTest extends PHPUnit_Framework_TestCase
 		$expected = '<div class="form-group"><label class="control-label" for="color">Favorite Color</label><select name="color" id="color" class="form-control"><option value="1">Red</option><option value="2">Green</option><option value="3">Blue</option></select></div>';
 
 		$options = array('1' => 'Red', '2' => 'Green', '3' => 'Blue');
-		$result = $this->form->select('Favorite Color', 'color', $options)->render();
+		$result = $this->form->select('Favorite Color', 'color', $options);
 		$this->assertEquals($expected, $result);
 	}
 
@@ -192,7 +192,7 @@ class BasicFormBuilderTest extends PHPUnit_Framework_TestCase
 	{
 		$expected = '<div class="form-group"><label class="control-label" for="color">Favorite Color</label><select name="color" id="color" class="form-control"><option value="1">Red</option><option value="2">Green</option><option value="3" selected>Blue</option></select></div>';
 		$options = array('1' => 'Red', '2' => 'Green', '3' => 'Blue');
-		$result = $this->form->select('Favorite Color', 'color', $options)->select('3')->render();
+		$result = $this->form->select('Favorite Color', 'color', $options)->select('3');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -207,7 +207,7 @@ class BasicFormBuilderTest extends PHPUnit_Framework_TestCase
 		$expected = '<div class="form-group has-error"><label class="control-label" for="color">Favorite Color</label><select name="color" id="color" class="form-control"><option value="1">Red</option><option value="2">Green</option><option value="3">Blue</option></select><p class="help-block">Color is required.</p></div>';
 
 		$options = array('1' => 'Red', '2' => 'Green', '3' => 'Blue');
-		$result = $this->form->select('Favorite Color', 'color', $options)->render();
+		$result = $this->form->select('Favorite Color', 'color', $options);
 		$this->assertEquals($expected, $result);
 	}
 
@@ -222,14 +222,14 @@ class BasicFormBuilderTest extends PHPUnit_Framework_TestCase
 		$expected = '<div class="form-group"><label class="control-label" for="color">Favorite Color</label><select name="color" id="color" class="form-control"><option value="1">Red</option><option value="2" selected>Green</option><option value="3">Blue</option></select></div>';
 
 		$options = array('1' => 'Red', '2' => 'Green', '3' => 'Blue');
-		$result = $this->form->select('Favorite Color', 'color', $options)->render();
+		$result = $this->form->select('Favorite Color', 'color', $options);
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testRenderCheckbox()
 	{
 		$expected = '<div class="checkbox"><label class="control-label"><input type="checkbox" name="terms" value="1">Agree to Terms</label></div>';
-		$result = $this->form->checkbox('Agree to Terms', 'terms')->render();
+		$result = $this->form->checkbox('Agree to Terms', 'terms');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -242,7 +242,7 @@ class BasicFormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->builder->setErrorStore($errorStore);
 
 		$expected = '<div class="has-error checkbox"><label class="control-label"><input type="checkbox" name="terms" value="1">Agree to Terms</label><p class="help-block">Must agree to terms.</p></div>';
-		$result = $this->form->checkbox('Agree to Terms', 'terms')->render();
+		$result = $this->form->checkbox('Agree to Terms', 'terms');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -255,21 +255,21 @@ class BasicFormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->builder->setOldInputProvider($oldInput);
 
 		$expected = '<div class="checkbox"><label class="control-label"><input type="checkbox" name="terms" value="1" checked="checked">Agree to Terms</label></div>';
-		$result = $this->form->checkbox('Agree to Terms', 'terms')->render();
+		$result = $this->form->checkbox('Agree to Terms', 'terms');
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testRenderCheckboxChecked()
 	{
 		$expected = '<div class="checkbox"><label class="control-label"><input type="checkbox" name="terms" value="1" checked="checked">Agree to Terms</label></div>';
-		$result = $this->form->checkbox('Agree to Terms', 'terms')->check()->render();
+		$result = $this->form->checkbox('Agree to Terms', 'terms')->check();
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testRenderRadio()
 	{
 		$expected = '<div class="radio"><label class="control-label"><input type="radio" name="color" value="red">Red</label></div>';
-		$result = $this->form->radio('Red', 'color', 'red')->render();
+		$result = $this->form->radio('Red', 'color', 'red');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -281,7 +281,7 @@ class BasicFormBuilderTest extends PHPUnit_Framework_TestCase
 
 		$this->builder->setErrorStore($errorStore);
 		$expected = '<div class="has-error radio"><label class="control-label"><input type="radio" name="color" value="red">Red</label><p class="help-block">Sample error</p></div>';
-		$result = $this->form->radio('Red', 'color', 'red')->render();
+		$result = $this->form->radio('Red', 'color', 'red');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -294,28 +294,28 @@ class BasicFormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->builder->setOldInputProvider($oldInput);
 
 		$expected = '<div class="radio"><label class="control-label"><input type="radio" name="color" value="red" checked="checked">Red</label></div>';
-		$result = $this->form->radio('Red', 'color', 'red')->render();
+		$result = $this->form->radio('Red', 'color', 'red');
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testRenderTextarea()
 	{
 		$expected = '<div class="form-group"><label class="control-label" for="bio">Bio</label><textarea name="bio" rows="10" cols="50" id="bio" class="form-control"></textarea></div>';
-		$result = $this->form->textarea('Bio', 'bio')->render();
+		$result = $this->form->textarea('Bio', 'bio');
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testRenderTextareaWithRows()
 	{
 		$expected = '<div class="form-group"><label class="control-label" for="bio">Bio</label><textarea name="bio" rows="5" cols="50" id="bio" class="form-control"></textarea></div>';
-		$result = $this->form->textarea('Bio', 'bio')->rows(5)->render();
+		$result = $this->form->textarea('Bio', 'bio')->rows(5);
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testRenderTextareaWithCols()
 	{
 		$expected = '<div class="form-group"><label class="control-label" for="bio">Bio</label><textarea name="bio" rows="10" cols="20" id="bio" class="form-control"></textarea></div>';
-		$result = $this->form->textarea('Bio', 'bio')->cols(20)->render();
+		$result = $this->form->textarea('Bio', 'bio')->cols(20);
 		$this->assertEquals($expected, $result);
 	}
 
@@ -327,7 +327,7 @@ class BasicFormBuilderTest extends PHPUnit_Framework_TestCase
 
 		$this->builder->setOldInputProvider($oldInput);
 		$expected = '<div class="form-group"><label class="control-label" for="bio">Bio</label><textarea name="bio" rows="10" cols="50" id="bio" class="form-control">Sample bio</textarea></div>';
-		$result = $this->form->textarea('Bio', 'bio')->render();
+		$result = $this->form->textarea('Bio', 'bio');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -339,42 +339,42 @@ class BasicFormBuilderTest extends PHPUnit_Framework_TestCase
 
 		$this->builder->setErrorStore($errorStore);
 		$expected = '<div class="form-group has-error"><label class="control-label" for="bio">Bio</label><textarea name="bio" rows="10" cols="50" id="bio" class="form-control"></textarea><p class="help-block">Sample error</p></div>';
-		$result = $this->form->textarea('Bio', 'bio')->render();
+		$result = $this->form->textarea('Bio', 'bio');
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testRenderInlineCheckbox()
 	{
 		$expected = '<label class="checkbox-inline"><input type="checkbox" name="terms" value="1">Agree to Terms</label>';
-		$result = $this->form->inlineCheckbox('Agree to Terms', 'terms')->render();
+		$result = $this->form->inlineCheckbox('Agree to Terms', 'terms');
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testRenderInlineRadio()
 	{
 		$expected = '<label class="radio-inline"><input type="radio" name="color" value="Red">Red</label>';
-		$result = $this->form->inlineRadio('Red', 'color')->render();
+		$result = $this->form->inlineRadio('Red', 'color');
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testFormOpen()
 	{
 		$expected = '<form method="POST" action="">';
-		$result = $this->form->open()->render();
+		$result = $this->form->open();
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testFormOpenGet()
 	{
 		$expected = '<form method="GET" action="">';
-		$result = $this->form->open()->get()->render();
+		$result = $this->form->open()->get();
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testFormOpenCustomAction()
 	{
 		$expected = '<form method="POST" action="/login">';
-		$result = $this->form->open()->action('/login')->render();
+		$result = $this->form->open()->action('/login');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -396,35 +396,35 @@ class BasicFormBuilderTest extends PHPUnit_Framework_TestCase
 	public function testFormOpenPut()
 	{
 		$expected = '<form method="POST" action=""><input type="hidden" name="_method" value="PUT">';
-		$result = $this->form->open()->put()->render();
+		$result = $this->form->open()->put();
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testFormOpenDelete()
 	{
 		$expected = '<form method="POST" action=""><input type="hidden" name="_method" value="DELETE">';
-		$result = $this->form->open()->delete()->render();
+		$result = $this->form->open()->delete();
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testRenderDateGroup()
 	{
 		$expected = '<div class="form-group"><label class="control-label" for="birthday">Birthday</label><input type="date" name="birthday" id="birthday" class="form-control"></div>';
-		$result = $this->form->date('Birthday', 'birthday')->render();
+		$result = $this->form->date('Birthday', 'birthday');
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testRenderEmailGroup()
 	{
 		$expected = '<div class="form-group"><label class="control-label" for="email">Email</label><input type="email" name="email" id="email" class="form-control"></div>';
-		$result = $this->form->email('Email', 'email')->render();
+		$result = $this->form->email('Email', 'email');
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testRenderFileGroup()
 	{
 		$expected = '<div class="form-group"><label class="control-label" for="file">File</label><input type="file" name="file" id="file"></div>';
-		$result = $this->form->file('File', 'file')->render();
+		$result = $this->form->file('File', 'file');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -436,7 +436,7 @@ class BasicFormBuilderTest extends PHPUnit_Framework_TestCase
 
 		$this->builder->setErrorStore($errorStore);
 		$expected = '<div class="form-group has-error"><label class="control-label" for="file">File</label><input type="file" name="file" id="file"><p class="help-block">Sample error</p></div>';
-		$result = $this->form->file('File', 'file')->render();
+		$result = $this->form->file('File', 'file');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -445,14 +445,14 @@ class BasicFormBuilderTest extends PHPUnit_Framework_TestCase
 		$expected = '<div class="form-group"><label class="control-label" for="color">Favorite Color</label><select name="color" id="color" class="form-control my-class"><option value="1">Red</option><option value="2">Green</option><option value="3">Blue</option></select></div>';
 
 		$options = array('1' => 'Red', '2' => 'Green', '3' => 'Blue');
-		$result = $this->form->select('Favorite Color', 'color', $options)->addClass('my-class')->render();
+		$result = $this->form->select('Favorite Color', 'color', $options)->addClass('my-class');
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testRenderTextGroupWithLabelClass()
 	{
 		$expected = '<div class="form-group"><label class="control-label required" for="email">Email</label><input type="text" name="email" id="email" class="form-control"></div>';
-		$result = $this->form->text('Email', 'email')->labelClass('required')->render();
+		$result = $this->form->text('Email', 'email')->labelClass('required');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -461,7 +461,7 @@ class BasicFormBuilderTest extends PHPUnit_Framework_TestCase
 		$object = $this->getStubObject();
 		$this->form->bind($object);
 		$expected = '<div class="form-group"><label class="control-label" for="first_name">First Name</label><input type="text" name="first_name" value="John" id="first_name" class="form-control"></div>';
-		$result = $this->form->text('First Name', 'first_name')->render();
+		$result = $this->form->text('First Name', 'first_name');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -469,21 +469,21 @@ class BasicFormBuilderTest extends PHPUnit_Framework_TestCase
 	public function testCanHideLabels()
 	{
 		$expected = '<div class="form-group"><label class="control-label sr-only" for="email">Email</label><input type="text" name="email" id="email" class="form-control"></div>';
-		$result = $this->form->text('Email', 'email')->hideLabel()->render();
+		$result = $this->form->text('Email', 'email')->hideLabel();
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testRenderInputGroupWithBeforeAddon()
 	{
 		$expected = '<div class="form-group"><label class="control-label" for="username">Username</label><div class="input-group"><span class="input-group-addon">@</span><input type="text" name="username" id="username" class="form-control"></div></div>';
-		$result = $this->form->inputGroup('Username', 'username')->beforeAddon('@')->render();
+		$result = $this->form->inputGroup('Username', 'username')->beforeAddon('@');
 		$this->assertEquals($expected, $result);
 	}
 
 	public function testRenderInputGroupWithAfterAddon()
 	{
 		$expected = '<div class="form-group"><label class="control-label" for="site">Site</label><div class="input-group"><input type="text" name="site" id="site" class="form-control"><span class="input-group-addon">.com.br</span></div></div>';
-		$result = $this->form->inputGroup('Site', 'site')->afterAddon('.com.br')->render();
+		$result = $this->form->inputGroup('Site', 'site')->afterAddon('.com.br');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -494,8 +494,7 @@ class BasicFormBuilderTest extends PHPUnit_Framework_TestCase
 			->inputGroup('Secret', 'secret')
 			->type('password')
 			->beforeAddon('before')
-			->afterAddon('after')
-			->render();
+			->afterAddon('after');
 		$this->assertEquals($expected, $result);
 	}
 


### PR DESCRIPTION
Removing `render()` calls from BasicFormBuilderTest.php tests (they should auto-render).  If `render()` is not required in practical use:
```
{!! BootForm::inlineRadio('Hidden', 'visibility') !!}
```
Then `render()` should not be called in your BasicFormBuilderTest.php tests.  Thoughts?