### PR TITLE
Fix for default value hydration of InputGroups

### DIFF
--- a/src/AdamWathan/BootForms/BasicFormBuilder.php
+++ b/src/AdamWathan/BootForms/BasicFormBuilder.php
@@ -173,7 +173,9 @@ class BasicFormBuilder
 	public function inputGroup($label, $name, $value = null)
 	{
 		$control = new InputGroup($name);
-		$control->value($value);
+		if (!is_null($value) || !is_null($value = $this->getValueFor($name))) {
+			$control->value($value);
+		}
 
 		return $this->formGroup($label, $name, $control);
 	}

--- a/tests/BasicFormBuilderTest.php
+++ b/tests/BasicFormBuilderTest.php
@@ -499,6 +499,65 @@ class BasicFormBuilderTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($expected, $result);
 	}
 
+	public function testRenderInputGroupWithValue()
+	{
+		$expected = '<div class="form-group"><label class="control-label" for="test">Test</label><div class="input-group"><input type="text" name="test" id="test" class="form-control" value="abc"></div></div>';
+		$result = $this->form->inputGroup('Test', 'test')->value('abc')->render();
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testRenderInputGroupWithOldInput()
+	{
+		$oldInput = Mockery::mock('AdamWathan\Form\OldInput\OldInputInterface');
+		$oldInput->shouldReceive('hasOldInput')->andReturn(true);
+		$oldInput->shouldReceive('getOldInput')->andReturn('xyz');
+
+		$this->builder->setOldInputProvider($oldInput);
+
+		$expected = '<div class="form-group"><label class="control-label" for="test">Test</label><div class="input-group"><input type="text" name="test" value="xyz" id="test" class="form-control"></div></div>';
+		$result = $this->form->inputGroup('Test', 'test')->render();
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testRenderInputGroupWithOldInputAndDefaultValue()
+	{
+		$oldInput = Mockery::mock('AdamWathan\Form\OldInput\OldInputInterface');
+		$oldInput->shouldReceive('hasOldInput')->andReturn(true);
+		$oldInput->shouldReceive('getOldInput')->andReturn('xyz');
+
+		$this->builder->setOldInputProvider($oldInput);
+
+		$expected = '<div class="form-group"><label class="control-label" for="test">Test</label><div class="input-group"><input type="text" name="test" value="xyz" id="test" class="form-control"></div></div>';
+		$result = $this->form->inputGroup('Test', 'test')->defaultValue('acb')->render();
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testRenderInputGroupWithDefaultValue()
+	{
+		$expected = '<div class="form-group"><label class="control-label" for="test">Test</label><div class="input-group"><input type="text" name="test" id="test" class="form-control" value="acb"></div></div>';
+		$result = $this->form->inputGroup('Test', 'test')->defaultValue('acb')->render();
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testRenderInputGroupWithOldInputAndError()
+	{
+		$oldInput = Mockery::mock('AdamWathan\Form\OldInput\OldInputInterface');
+		$oldInput->shouldReceive('hasOldInput')->andReturn(true);
+		$oldInput->shouldReceive('getOldInput')->andReturn('abc');
+
+		$this->builder->setOldInputProvider($oldInput);
+
+		$errorStore = Mockery::mock('AdamWathan\Form\ErrorStore\ErrorStoreInterface');
+		$errorStore->shouldReceive('hasError')->andReturn(true);
+		$errorStore->shouldReceive('getError')->andReturn('Test is required.');
+
+		$this->builder->setErrorStore($errorStore);
+
+		$expected = '<div class="form-group has-error"><label class="control-label" for="test">Test</label><div class="input-group"><input type="text" name="test" value="abc" id="test" class="form-control"></div><p class="help-block">Test is required.</p></div>';
+		$result = $this->form->inputGroup('Test', 'test')->render();
+		$this->assertEquals($expected, $result);
+	}
+
 	private function getStubObject()
 	{
 		$obj = new stdClass;

--- a/tests/InputGroupTest.php
+++ b/tests/InputGroupTest.php
@@ -35,4 +35,37 @@ class InputGroupTest extends PHPUnit_Framework_TestCase
 		$result = $input->render();
 		$this->assertEquals($expected, $result);		
 	}
+
+	public function testCanRenderWithValue()
+	{
+		$input = new InputGroup('test');
+		$input = $input->value('abc');
+		$expected = '<div class="input-group"><input type="text" name="test" value="abc"></div>';
+		$result = $input->render();
+		$this->assertEquals($expected, $result);
+
+		$input = new InputGroup('test');
+		$input = $input->value(null);
+		$expected = '<div class="input-group"><input type="text" name="test"></div>';
+		$result = $input->render();
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testDefaultValue()
+	{
+		$input = new InputGroup('test');
+		$expected = '<div class="input-group"><input type="text" name="test" value="abc"></div>';
+		$result = $input->defaultValue('abc')->render();
+		$this->assertEquals($expected, $result);
+
+		$input = new InputGroup('test');
+		$expected = '<div class="input-group"><input type="text" name="test" value="xyz"></div>';
+		$result = $input->value('xyz')->defaultValue('abc')->render();
+		$this->assertEquals($expected, $result);
+
+		$input = new InputGroup('test');
+		$expected = '<div class="input-group"><input type="text" name="test" value="xyz"></div>';
+		$result = $input->defaultValue('abc')->value('xyz')->render();
+		$this->assertEquals($expected, $result);
+	}
 }


### PR DESCRIPTION
The new InputGroup element doesn't correctly hydrate from old input or bound models.

While other elements implement this functionality through the core Form package, the InputGroup element is specific to BootForms and cannot rely on this cascade. Therefore default value hydration for InputGroups needs to be implemented explicitly.