### PR TITLE
Issue with offset value on non full-width forms

### DIFF
--- a/src/AdamWathan/BootForms/Elements/OffsetFormGroup.php
+++ b/src/AdamWathan/BootForms/Elements/OffsetFormGroup.php
@@ -33,8 +33,7 @@ class OffsetFormGroup
     {
         $class = '';
         foreach ($this->columnSizes as $breakpoint => $sizes) {
-            $offset = 12 - $sizes[1];
-            $class .= sprintf('col-%s-offset-%s col-%s-%s ', $breakpoint, $offset, $breakpoint, $sizes[1]);
+            $class .= sprintf('col-%s-offset-%s col-%s-%s ', $breakpoint, $sizes[0], $breakpoint, $sizes[1]);
         }
         return trim($class);
     }

--- a/tests/HorizontalFormBuilderTest.php
+++ b/tests/HorizontalFormBuilderTest.php
@@ -205,6 +205,14 @@ class HorizontalFormBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $result);
     }
 
+    public function testRenderButtonWithMultipleBreakpointSizesThatDontFillFullWidth()
+    {
+        $this->form->setColumnSizes(['xs' => [5, 7], 'lg' => [3, 6]]);
+        $expected = '<div class="form-group"><div class="col-xs-offset-5 col-xs-7 col-lg-offset-3 col-lg-6"><button type="button" class="btn btn-default">Click Me</button></div></div>';
+        $result = $this->form->button('Click Me')->render();
+        $this->assertEquals($expected, $result);
+    }
+
     public function testRenderSubmit()
     {
         $expected = '<div class="form-group"><div class="col-lg-offset-2 col-lg-10"><button type="submit" class="btn btn-default">Submit</button></div></div>';


### PR DESCRIPTION
Hi Adam,

First thanks for the awesome package, it saves me a lot of time!

Recently I had an issue with your offset class if your column sizes don't add up to 12 (full width). My example code:
```php
{!! BootForm::openHorizontal([ 'sm' => [4, 8], 'lg' => [4, 6] ])->post()->action('/feeds') !!}
    {!! BootForm::submit('Submit') !!}
{!! BootForm::close() !!}
```
Notice at the 'lg' break point I only want the labels/offsets to be 4 and the inputs to be 6. Unfortunately it was resulting in this html for the submit button:
```html
<div class="col-sm-offset-4 col-sm-8 col-lg-offset-6 col-lg-6">
    <button type="submit" class="btn btn-default">Submit</button>
</div>
```
As you can see the offset is 6, causing misalignment.

I've submitted a test proving the issue and also the fix in your `OffsetFormGroup`