### PR TITLE
Make extension easier by protecting these privates?

### DIFF
--- a/src/AdamWathan/BootForms/BootForm.php
+++ b/src/AdamWathan/BootForms/BootForm.php
@@ -2,9 +2,9 @@
 
 class BootForm
 {
-    private $builder;
-    private $basicFormBuilder;
-    private $horizontalFormBuilder;
+    protected $builder;
+    protected $basicFormBuilder;
+    protected $horizontalFormBuilder;
 
     public function __construct(BasicFormBuilder $basicFormBuilder, HorizontalFormBuilder $horizontalFormBuilder)
     {

--- a/src/AdamWathan/BootForms/HorizontalFormBuilder.php
+++ b/src/AdamWathan/BootForms/HorizontalFormBuilder.php
@@ -8,7 +8,7 @@ use AdamWathan\Form\FormBuilder;
 
 class HorizontalFormBuilder extends BasicFormBuilder
 {
-    private $columnSizes;
+    protected $columnSizes;
 
     protected $builder;
 


### PR DESCRIPTION
Because some of these properties are private, extending these classes requires re-implementing these properties and all related methods.  If we protect them, the classes are more flexible for people who wish to extend.