### PR TITLE
add Htmlable, so the cleaner {{ can be used instead of {!!

### DIFF
--- a/src/AdamWathan/BootForms/Elements/GroupWrapper.php
+++ b/src/AdamWathan/BootForms/Elements/GroupWrapper.php
@@ -1,8 +1,9 @@
 <?php namespace AdamWathan\BootForms\Elements;
 
 use AdamWathan\Form\Elements\Label;
+use Illuminate\Contracts\Support\Htmlable;
 
-class GroupWrapper
+class GroupWrapper implements Htmlable
 {
     protected $formGroup;
     protected $target;
@@ -87,5 +88,14 @@ class GroupWrapper
     {
         call_user_func_array([$this->target, $method], $parameters);
         return $this;
+    }
+
+    /**
+     * Get content as a string of HTML.
+     *
+     * @return string
+     */
+    public function toHtml() {
+        return $this->render();
     }
 }

--- a/src/AdamWathan/BootForms/Elements/OffsetFormGroup.php
+++ b/src/AdamWathan/BootForms/Elements/OffsetFormGroup.php
@@ -1,6 +1,8 @@
 <?php namespace AdamWathan\BootForms\Elements;
 
-class OffsetFormGroup
+use Illuminate\Contracts\Support\Htmlable;
+
+class OffsetFormGroup implements Htmlable
 {
     protected $control;
     protected $columnSizes;
@@ -47,5 +49,14 @@ class OffsetFormGroup
     {
         call_user_func_array([$this->control, $method], $parameters);
         return $this;
+    }
+
+    /**
+     * Get content as a string of HTML.
+     *
+     * @return string
+     */
+    public function toHtml() {
+        return $this->render();
     }
 }

--- a/tests/FormGroupTest.php
+++ b/tests/FormGroupTest.php
@@ -22,6 +22,17 @@ class FormGroupTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $result);
     }
 
+   public function testCanGetHtmlFromBasicFormGroup()
+    {
+        $label = $this->builder->label('Email');
+        $text = $this->builder->text('email');
+        $formGroup = new FormGroup($label, $text);
+
+        $expected = $formGroup->render();;
+        $result = $formGroup->toHtml();
+        $this->assertEquals($expected, $result);
+    }
+
     public function testCanRenderWithPlaceholder()
     {
         $label = $this->builder->label('Email');


### PR DESCRIPTION
Make all Elements/Groups Htmlable so the Helper can used "cleaner" 
{{ Form::text() }} instead of {!! Form::text() !!}
