### PR TITLE
Support for ->required() on the label within a form group

### DIFF
--- a/src/AdamWathan/BootForms/Elements/GroupWrapper.php
+++ b/src/AdamWathan/BootForms/Elements/GroupWrapper.php
@@ -58,6 +58,16 @@ class GroupWrapper
         $this->labelClass('sr-only');
         return $this;
     }
+    
+    public function required($conditional = true)
+    {
+        if ($conditional) {
+            $this->formGroup->label()->addClass('control-label-required');
+        }
+
+        call_user_func_array([$this->target, 'required'], [$conditional]);
+        return $this;
+    }
 
     public function inline()
     {

--- a/tests/BasicFormBuilderTest.php
+++ b/tests/BasicFormBuilderTest.php
@@ -528,6 +528,17 @@ class BasicFormBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $result);
     }
 
+    public function testRequiredLabels()
+    {
+        $expected = '<div class="form-group"><label class="control-label control-label-required" for="email">Email</label><input type="text" name="email" id="email" class="form-control" required="required"></div>';
+        $result = $this->form->text('Email', 'email')->required()->render();
+        $this->assertEquals($expected, $result);
+
+        $expected = '<div class="form-group"><label class="control-label" for="email">Email</label><input type="text" name="email" id="email" class="form-control"></div>';
+        $result = $this->form->text('Email', 'email')->required(false)->render();
+        $this->assertEquals($expected, $result);
+    }
+
     public function testCanAddGroupClass()
     {
         $expected = '<div class="form-group test-class"><label class="control-label" for="email">Email</label><input type="text" name="email" id="email" class="form-control"></div>';


### PR DESCRIPTION
By intercepting the `required($conditional)` function here we will add automatically the `control-label-required` CSS class to the `<label>` HTML element.

This way you are able to use CSS to style the `<label>` HTML element however you want, you can even use pseudo-elements to add an asterisk:
```css
label.control-label-required:after {
    content: " *";
}
```

Obviously we wont interfere with Form Builder and we'll call the `required()` function defined within `adamwathan/form` no matter what. The CSS class will just be added conditionally.