### PR TITLE
Support Laravel 5.5 auto-discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,5 +22,15 @@
             "AdamWathan\\BootForms": "src/"
         }
     },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "AdamWathan\\BootForms\\BootFormsServiceProvider"
+            ],
+            "aliases": {
+                "BootForm": "AdamWathan\\BootForms\\Facades\\BootForm"
+            }
+        }
+    },
     "minimum-stability": "stable"
 }

--- a/src/AdamWathan/BootForms/BasicFormBuilder.php
+++ b/src/AdamWathan/BootForms/BasicFormBuilder.php
@@ -7,15 +7,32 @@ use AdamWathan\BootForms\Elements\HelpBlock;
 use AdamWathan\BootForms\Elements\InputGroup;
 use AdamWathan\Form\FormBuilder;
 
+/**
+ * Class BasicFormBuilder
+ * @package AdamWathan\BootForms
+ */
 class BasicFormBuilder
 {
+	/**
+     * @var FormBuilder
+     */
     protected $builder;
 
+	/**
+     * BasicFormBuilder constructor.
+     * @param FormBuilder $builder
+     */
     public function __construct(FormBuilder $builder)
     {
         $this->builder = $builder;
     }
 
+	/**
+     * @param $label
+     * @param $name
+     * @param $control
+     * @return GroupWrapper
+     */
     protected function formGroup($label, $name, $control)
     {
         $label = $this->builder->label($label)->addClass('control-label')->forId($name);
@@ -31,11 +48,21 @@ class BasicFormBuilder
         return $this->wrap($formGroup);
     }
 
+	/**
+     * @param $group
+     * @return GroupWrapper
+     */
     protected function wrap($group)
     {
         return new GroupWrapper($group);
     }
 
+	/**
+     * @param $label
+     * @param $name
+     * @param null $value
+     * @return GroupWrapper
+     */
     public function text($label, $name, $value = null)
     {
         $control = $this->builder->text($name)->value($value);
@@ -43,6 +70,11 @@ class BasicFormBuilder
         return $this->formGroup($label, $name, $control);
     }
 
+	/**
+     * @param $label
+     * @param $name
+     * @return GroupWrapper
+     */
     public function password($label, $name)
     {
         $control = $this->builder->password($name);
@@ -50,16 +82,33 @@ class BasicFormBuilder
         return $this->formGroup($label, $name, $control);
     }
 
+	/**
+     * @param $value
+     * @param null $name
+     * @param string $type
+     * @return \AdamWathan\Form\Elements\Button
+     */
     public function button($value, $name = null, $type = "btn-default")
     {
         return $this->builder->button($value, $name)->addClass('btn')->addClass($type);
     }
 
+	/**
+     * @param string $value
+     * @param string $type
+     * @return \AdamWathan\Form\Elements\Button
+     */
     public function submit($value = "Submit", $type = "btn-default")
     {
         return $this->builder->submit($value)->addClass('btn')->addClass($type);
     }
 
+    /**
+     * @param $label
+     * @param $name
+     * @param array $options
+     * @return GroupWrapper
+     */
     public function select($label, $name, $options = [])
     {
         $control = $this->builder->select($name, $options);
@@ -67,6 +116,11 @@ class BasicFormBuilder
         return $this->formGroup($label, $name, $control);
     }
 
+	/**
+     * @param $label
+     * @param $name
+     * @return GroupWrapper
+     */
     public function checkbox($label, $name)
     {
         $control = $this->builder->checkbox($name);
@@ -74,17 +128,34 @@ class BasicFormBuilder
         return $this->checkGroup($label, $name, $control);
     }
 
+	/**
+     * @param $label
+     * @param $name
+     * @return $this
+     */
     public function inlineCheckbox($label, $name)
     {
         return $this->checkbox($label, $name)->inline();
     }
 
+	/**
+     * @param $label
+     * @param $name
+     * @param $control
+     * @return GroupWrapper
+     */
     protected function checkGroup($label, $name, $control)
     {
         $checkGroup = $this->buildCheckGroup($label, $name, $control);
         return $this->wrap($checkGroup->addClass('checkbox'));
     }
 
+	/**
+     * @param $label
+     * @param $name
+     * @param $control
+     * @return CheckGroup
+     */
     protected function buildCheckGroup($label, $name, $control)
     {
         $label = $this->builder->label($label, $name)->after($control)->addClass('control-label');
@@ -98,6 +169,12 @@ class BasicFormBuilder
         return $checkGroup;
     }
 
+	/**
+     * @param $label
+     * @param $name
+     * @param null $value
+     * @return GroupWrapper
+     */
     public function radio($label, $name, $value = null)
     {
         if (is_null($value)) {
@@ -109,17 +186,34 @@ class BasicFormBuilder
         return $this->radioGroup($label, $name, $control);
     }
 
+	/**
+     * @param $label
+     * @param $name
+     * @param null $value
+     * @return \AdamWathan\Form\Elements\RadioButton
+     */
     public function inlineRadio($label, $name, $value = null)
     {
         return $this->radio($label, $name, $value)->inline();
     }
 
+	/**
+     * @param $label
+     * @param $name
+     * @param $control
+     * @return GroupWrapper
+     */
     protected function radioGroup($label, $name, $control)
     {
         $checkGroup = $this->buildCheckGroup($label, $name, $control);
         return $this->wrap($checkGroup->addClass('radio'));
     }
 
+	/**
+     * @param $label
+     * @param $name
+     * @return GroupWrapper
+     */
     public function textarea($label, $name)
     {
         $control = $this->builder->textarea($name);
@@ -127,6 +221,12 @@ class BasicFormBuilder
         return $this->formGroup($label, $name, $control);
     }
 
+	/**
+     * @param $label
+     * @param $name
+     * @param null $value
+     * @return GroupWrapper
+     */
     public function date($label, $name, $value = null)
     {
         $control = $this->builder->date($name)->value($value);
@@ -134,6 +234,12 @@ class BasicFormBuilder
         return $this->formGroup($label, $name, $control);
     }
 
+	/**
+     * @param $label
+     * @param $name
+     * @param null $value
+     * @return GroupWrapper
+     */
     public function email($label, $name, $value = null)
     {
         $control = $this->builder->email($name)->value($value);
@@ -141,6 +247,12 @@ class BasicFormBuilder
         return $this->formGroup($label, $name, $control);
     }
 
+	/**
+     * @param $label
+     * @param $name
+     * @param null $value
+     * @return GroupWrapper
+     */
     public function file($label, $name, $value = null)
     {
         $control = $this->builder->file($name)->value($value);
@@ -157,6 +269,12 @@ class BasicFormBuilder
         return $this->wrap($formGroup);
     }
 
+	/**
+     * @param $label
+     * @param $name
+     * @param null $value
+     * @return GroupWrapper
+     */
     public function inputGroup($label, $name, $value = null)
     {
         $control = new InputGroup($name);
@@ -167,6 +285,11 @@ class BasicFormBuilder
         return $this->formGroup($label, $name, $control);
     }
 
+	/**
+     * @param $method
+     * @param $parameters
+     * @return mixed
+     */
     public function __call($method, $parameters)
     {
         return call_user_func_array([$this->builder, $method], $parameters);

--- a/src/AdamWathan/BootForms/BasicFormBuilder.php
+++ b/src/AdamWathan/BootForms/BasicFormBuilder.php
@@ -13,12 +13,12 @@ use AdamWathan\Form\FormBuilder;
  */
 class BasicFormBuilder
 {
-	/**
+    /**
      * @var FormBuilder
      */
     protected $builder;
 
-	/**
+    /**
      * BasicFormBuilder constructor.
      * @param FormBuilder $builder
      */
@@ -27,7 +27,7 @@ class BasicFormBuilder
         $this->builder = $builder;
     }
 
-	/**
+    /**
      * @param $label
      * @param $name
      * @param $control
@@ -48,7 +48,7 @@ class BasicFormBuilder
         return $this->wrap($formGroup);
     }
 
-	/**
+    /**
      * @param $group
      * @return GroupWrapper
      */
@@ -57,7 +57,7 @@ class BasicFormBuilder
         return new GroupWrapper($group);
     }
 
-	/**
+    /**
      * @param $label
      * @param $name
      * @param null $value
@@ -70,7 +70,7 @@ class BasicFormBuilder
         return $this->formGroup($label, $name, $control);
     }
 
-	/**
+    /**
      * @param $label
      * @param $name
      * @return GroupWrapper
@@ -82,7 +82,7 @@ class BasicFormBuilder
         return $this->formGroup($label, $name, $control);
     }
 
-	/**
+    /**
      * @param $value
      * @param null $name
      * @param string $type
@@ -93,7 +93,7 @@ class BasicFormBuilder
         return $this->builder->button($value, $name)->addClass('btn')->addClass($type);
     }
 
-	/**
+    /**
      * @param string $value
      * @param string $type
      * @return \AdamWathan\Form\Elements\Button
@@ -116,7 +116,7 @@ class BasicFormBuilder
         return $this->formGroup($label, $name, $control);
     }
 
-	/**
+    /**
      * @param $label
      * @param $name
      * @return GroupWrapper
@@ -128,7 +128,7 @@ class BasicFormBuilder
         return $this->checkGroup($label, $name, $control);
     }
 
-	/**
+    /**
      * @param $label
      * @param $name
      * @return $this
@@ -138,7 +138,7 @@ class BasicFormBuilder
         return $this->checkbox($label, $name)->inline();
     }
 
-	/**
+    /**
      * @param $label
      * @param $name
      * @param $control
@@ -150,7 +150,7 @@ class BasicFormBuilder
         return $this->wrap($checkGroup->addClass('checkbox'));
     }
 
-	/**
+    /**
      * @param $label
      * @param $name
      * @param $control
@@ -169,7 +169,7 @@ class BasicFormBuilder
         return $checkGroup;
     }
 
-	/**
+    /**
      * @param $label
      * @param $name
      * @param null $value
@@ -186,7 +186,7 @@ class BasicFormBuilder
         return $this->radioGroup($label, $name, $control);
     }
 
-	/**
+    /**
      * @param $label
      * @param $name
      * @param null $value
@@ -197,7 +197,7 @@ class BasicFormBuilder
         return $this->radio($label, $name, $value)->inline();
     }
 
-	/**
+    /**
      * @param $label
      * @param $name
      * @param $control
@@ -209,7 +209,7 @@ class BasicFormBuilder
         return $this->wrap($checkGroup->addClass('radio'));
     }
 
-	/**
+    /**
      * @param $label
      * @param $name
      * @return GroupWrapper
@@ -221,7 +221,7 @@ class BasicFormBuilder
         return $this->formGroup($label, $name, $control);
     }
 
-	/**
+    /**
      * @param $label
      * @param $name
      * @param null $value
@@ -234,7 +234,7 @@ class BasicFormBuilder
         return $this->formGroup($label, $name, $control);
     }
 
-	/**
+    /**
      * @param $label
      * @param $name
      * @param null $value
@@ -247,7 +247,7 @@ class BasicFormBuilder
         return $this->formGroup($label, $name, $control);
     }
 
-	/**
+    /**
      * @param $label
      * @param $name
      * @param null $value
@@ -269,7 +269,7 @@ class BasicFormBuilder
         return $this->wrap($formGroup);
     }
 
-	/**
+    /**
      * @param $label
      * @param $name
      * @param null $value
@@ -285,7 +285,7 @@ class BasicFormBuilder
         return $this->formGroup($label, $name, $control);
     }
 
-	/**
+    /**
      * @param $method
      * @param $parameters
      * @return mixed

--- a/src/AdamWathan/BootForms/BootForm.php
+++ b/src/AdamWathan/BootForms/BootForm.php
@@ -29,22 +29,22 @@
  */
 class BootForm
 {
-	/**
+    /**
 	 * @var BasicFormBuilder
 	 */
     protected $builder;
 
-	/**
+    /**
 	 * @var BasicFormBuilder
 	 */
 	protected $basicFormBuilder;
 
-	/**
+    /**
 	 * @var HorizontalFormBuilder
 	 */
 	protected $horizontalFormBuilder;
 
-	/**
+    /**
 	 * BootForm constructor.
 	 * @param BasicFormBuilder $basicFormBuilder
 	 * @param HorizontalFormBuilder $horizontalFormBuilder
@@ -55,7 +55,7 @@ class BootForm
         $this->horizontalFormBuilder = $horizontalFormBuilder;
     }
 
-	/**
+    /**
 	 * @return \AdamWathan\Form\Elements\FormOpen
 	 */
     public function open()
@@ -64,7 +64,7 @@ class BootForm
         return $this->builder->open();
     }
 
-	/**
+    /**
 	 * @param $columnSizes
 	 * @return \AdamWathan\Form\Elements\FormOpen
 	 */

--- a/src/AdamWathan/BootForms/BootForm.php
+++ b/src/AdamWathan/BootForms/BootForm.php
@@ -1,23 +1,73 @@
 <?php namespace AdamWathan\BootForms;
 
+/**
+ * Class BootForm
+ * @package AdamWathan\BootForms
+ * @method \AdamWathan\Form\Elements\Text text($name)
+ * @method \AdamWathan\Form\Elements\Date date($name)
+ * @method \AdamWathan\Form\Elements\Email email($name)
+ * @method \AdamWathan\Form\Elements\Hidden hidden($name)
+ * @method \AdamWathan\Form\Elements\TextArea textarea($name)
+ * @method \AdamWathan\Form\Elements\Password password($name)
+ * @method \AdamWathan\Form\Elements\Checkbox checkbox($name, $value = 1)
+ * @method \AdamWathan\Form\Elements\RadioButton radio($name, $value = null)
+ * @method \AdamWathan\Form\Elements\Button button($value, $name = null)
+ * @method \AdamWathan\Form\Elements\Button submit($value = 'Submit')
+ * @method \AdamWathan\Form\Elements\Select select($name, $options = [])
+ * @method \AdamWathan\Form\Elements\Label label($label)
+ * @method \AdamWathan\Form\Elements\File file($name)
+ * @method setOldInputProvider(\AdamWathan\Form\OldInput\OldInputInterface $oldInputProvider)
+ * @method setErrorStore(\AdamWathan\Form\ErrorStore\ErrorStoreInterface $errorStore)
+ * @method setToken($token)
+ * @method string close()
+ * @method string token()
+ * @method bool hasError($name)
+ * @method string getError($name, $format = null)
+ * @method  bind($data)
+ * @method mixed getValueFor($name)
+ * @method \AdamWathan\Form\Elements\Select selectMonth($name)
+ */
 class BootForm
 {
+	/**
+	 * @var BasicFormBuilder
+	 */
     protected $builder;
-    protected $basicFormBuilder;
-    protected $horizontalFormBuilder;
 
+	/**
+	 * @var BasicFormBuilder
+	 */
+	protected $basicFormBuilder;
+
+	/**
+	 * @var HorizontalFormBuilder
+	 */
+	protected $horizontalFormBuilder;
+
+	/**
+	 * BootForm constructor.
+	 * @param BasicFormBuilder $basicFormBuilder
+	 * @param HorizontalFormBuilder $horizontalFormBuilder
+	 */
     public function __construct(BasicFormBuilder $basicFormBuilder, HorizontalFormBuilder $horizontalFormBuilder)
     {
         $this->basicFormBuilder = $basicFormBuilder;
         $this->horizontalFormBuilder = $horizontalFormBuilder;
     }
 
+	/**
+	 * @return \AdamWathan\Form\Elements\FormOpen
+	 */
     public function open()
     {
         $this->builder = $this->basicFormBuilder;
         return $this->builder->open();
     }
 
+	/**
+	 * @param $columnSizes
+	 * @return \AdamWathan\Form\Elements\FormOpen
+	 */
     public function openHorizontal($columnSizes)
     {
         $this->horizontalFormBuilder->setColumnSizes($columnSizes);

--- a/src/AdamWathan/BootForms/Elements/CheckGroup.php
+++ b/src/AdamWathan/BootForms/Elements/CheckGroup.php
@@ -2,16 +2,33 @@
 
 use AdamWathan\Form\Elements\Label;
 
+/**
+ * Class CheckGroup
+ * @package AdamWathan\BootForms\Elements
+ */
 class CheckGroup extends FormGroup
 {
+	/**
+     * @var Label
+     */
     protected $label;
+	/**
+     * @var bool
+     */
     protected $inline = false;
 
+	/**
+     * CheckGroup constructor.
+     * @param Label $label
+     */
     public function __construct(Label $label)
     {
         $this->label = $label;
     }
 
+	/**
+     * @return string
+     */
     public function render()
     {
         if ($this->inline === true) {
@@ -29,6 +46,9 @@ class CheckGroup extends FormGroup
         return $html;
     }
 
+	/**
+     * @return $this
+     */
     public function inline()
     {
         $this->inline = true;
@@ -39,11 +59,19 @@ class CheckGroup extends FormGroup
         return $this;
     }
 
+	/**
+     * @return \AdamWathan\Form\Elements\Element
+     */
     public function control()
     {
         return $this->label->getControl();
     }
 
+	/**
+     * @param $method
+     * @param $parameters
+     * @return $this
+     */
     public function __call($method, $parameters)
     {
         call_user_func_array([$this->label->getControl(), $method], $parameters);

--- a/src/AdamWathan/BootForms/Elements/CheckGroup.php
+++ b/src/AdamWathan/BootForms/Elements/CheckGroup.php
@@ -8,16 +8,16 @@ use AdamWathan\Form\Elements\Label;
  */
 class CheckGroup extends FormGroup
 {
-	/**
+    /**
      * @var Label
      */
     protected $label;
-	/**
+    /**
      * @var bool
      */
     protected $inline = false;
 
-	/**
+    /**
      * CheckGroup constructor.
      * @param Label $label
      */
@@ -26,7 +26,7 @@ class CheckGroup extends FormGroup
         $this->label = $label;
     }
 
-	/**
+    /**
      * @return string
      */
     public function render()
@@ -46,7 +46,7 @@ class CheckGroup extends FormGroup
         return $html;
     }
 
-	/**
+    /**
      * @return $this
      */
     public function inline()
@@ -59,7 +59,7 @@ class CheckGroup extends FormGroup
         return $this;
     }
 
-	/**
+    /**
      * @return \AdamWathan\Form\Elements\Element
      */
     public function control()
@@ -67,7 +67,7 @@ class CheckGroup extends FormGroup
         return $this->label->getControl();
     }
 
-	/**
+    /**
      * @param $method
      * @param $parameters
      * @return $this

--- a/src/AdamWathan/BootForms/Elements/FormGroup.php
+++ b/src/AdamWathan/BootForms/Elements/FormGroup.php
@@ -3,12 +3,30 @@
 use AdamWathan\Form\Elements\Element;
 use AdamWathan\Form\Elements\Label;
 
+/**
+ * Class FormGroup
+ * @package AdamWathan\BootForms\Elements
+ */
 class FormGroup extends Element
 {
+	/**
+     * @var Label
+     */
     protected $label;
+	/**
+     * @var Element
+     */
     protected $control;
+	/**
+     * @var
+     */
     protected $helpBlock;
 
+	/**
+     * FormGroup constructor.
+     * @param Label $label
+     * @param Element $control
+     */
     public function __construct(Label $label, Element $control)
     {
         $this->label = $label;
@@ -16,6 +34,9 @@ class FormGroup extends Element
         $this->addClass('form-group');
     }
 
+	/**
+     * @return string
+     */
     public function render()
     {
         $html = '<div';
@@ -30,6 +51,10 @@ class FormGroup extends Element
         return $html;
     }
 
+	/**
+     * @param $text
+     * @return $this|void
+     */
     public function helpBlock($text)
     {
         if (isset($this->helpBlock)) {
@@ -39,6 +64,9 @@ class FormGroup extends Element
         return $this;
     }
 
+	/**
+     * @return string
+     */
     protected function renderHelpBlock()
     {
         if ($this->helpBlock) {
@@ -48,16 +76,27 @@ class FormGroup extends Element
         return '';
     }
 
+	/**
+     * @return Element
+     */
     public function control()
     {
         return $this->control;
     }
 
+	/**
+     * @return Label
+     */
     public function label()
     {
         return $this->label;
     }
 
+	/**
+     * @param $method
+     * @param $parameters
+     * @return $this
+     */
     public function __call($method, $parameters)
     {
         call_user_func_array([$this->control, $method], $parameters);

--- a/src/AdamWathan/BootForms/Elements/FormGroup.php
+++ b/src/AdamWathan/BootForms/Elements/FormGroup.php
@@ -9,20 +9,20 @@ use AdamWathan\Form\Elements\Label;
  */
 class FormGroup extends Element
 {
-	/**
+    /**
      * @var Label
      */
     protected $label;
-	/**
+    /**
      * @var Element
      */
     protected $control;
-	/**
+    /**
      * @var
      */
     protected $helpBlock;
 
-	/**
+    /**
      * FormGroup constructor.
      * @param Label $label
      * @param Element $control
@@ -34,7 +34,7 @@ class FormGroup extends Element
         $this->addClass('form-group');
     }
 
-	/**
+    /**
      * @return string
      */
     public function render()
@@ -51,7 +51,7 @@ class FormGroup extends Element
         return $html;
     }
 
-	/**
+    /**
      * @param $text
      * @return $this|void
      */
@@ -64,7 +64,7 @@ class FormGroup extends Element
         return $this;
     }
 
-	/**
+    /**
      * @return string
      */
     protected function renderHelpBlock()
@@ -76,7 +76,7 @@ class FormGroup extends Element
         return '';
     }
 
-	/**
+    /**
      * @return Element
      */
     public function control()
@@ -84,7 +84,7 @@ class FormGroup extends Element
         return $this->control;
     }
 
-	/**
+    /**
      * @return Label
      */
     public function label()
@@ -92,7 +92,7 @@ class FormGroup extends Element
         return $this->label;
     }
 
-	/**
+    /**
      * @param $method
      * @param $parameters
      * @return $this

--- a/src/AdamWathan/BootForms/Elements/GroupWrapper.php
+++ b/src/AdamWathan/BootForms/Elements/GroupWrapper.php
@@ -2,87 +2,149 @@
 
 use AdamWathan\Form\Elements\Label;
 
+/**
+ * Class GroupWrapper
+ * @package AdamWathan\BootForms\Elements
+ */
 class GroupWrapper
 {
+	/**
+     * @var FormGroup
+     */
     protected $formGroup;
+
+	/**
+     * @var
+     */
     protected $target;
 
-    public function __construct($formGroup)
+    /**
+     * GroupWrapper constructor.
+     * @param FormGroup $formGroup
+     */
+    public function __construct(FormGroup $formGroup)
     {
         $this->formGroup = $formGroup;
         $this->target = $formGroup->control();
     }
 
+	/**
+     * @return string
+     */
     public function render()
     {
         return $this->formGroup->render();
     }
 
+	/**
+     * @param $text
+     * @return $this
+     */
     public function helpBlock($text)
     {
         $this->formGroup->helpBlock($text);
         return $this;
     }
 
+	/**
+     * @return string
+     */
     public function __toString()
     {
         return $this->render();
     }
 
+	/**
+     * @param string $class
+     * @return $this
+     */
     public function addGroupClass($class)
     {
         $this->formGroup->addClass($class);
         return $this;
     }
 
+	/**
+     * @param string $class
+     * @return $this
+     */
     public function removeGroupClass($class)
     {
         $this->formGroup->removeClass($class);
         return $this;
     }
 
+	/**
+     * @param string $attribute
+     * @param string $value
+     * @return $this
+     */
     public function groupData($attribute, $value)
     {
         $this->formGroup->data($attribute, $value);
         return $this;
     }
 
+	/**
+     * @param string $class
+     * @return $this
+     */
     public function labelClass($class)
     {
         $this->formGroup->label()->addClass($class);
         return $this;
     }
 
+	/**
+     * @return $this
+     */
     public function hideLabel()
     {
         $this->labelClass('sr-only');
         return $this;
     }
 
+	/**
+     * @return $this
+     */
     public function inline()
     {
         $this->formGroup->inline();
         return $this;
     }
 
+	/**
+     * @return $this
+     */
     public function group()
     {
         $this->target = $this->formGroup;
         return $this;
     }
 
+	/**
+     * @return $this
+     */
     public function label()
     {
         $this->target = $this->formGroup->label();
         return $this;
     }
 
+	/**
+     * @return $this
+     */
     public function control()
     {
         $this->target = $this->formGroup->control();
         return $this;
     }
 
+	/**
+     * @param $method
+     * @param $parameters
+     * @return $this
+     */
     public function __call($method, $parameters)
     {
         call_user_func_array([$this->target, $method], $parameters);

--- a/src/AdamWathan/BootForms/Elements/GroupWrapper.php
+++ b/src/AdamWathan/BootForms/Elements/GroupWrapper.php
@@ -8,12 +8,12 @@ use AdamWathan\Form\Elements\Label;
  */
 class GroupWrapper
 {
-	/**
+    /**
      * @var FormGroup
      */
     protected $formGroup;
 
-	/**
+    /**
      * @var
      */
     protected $target;
@@ -28,7 +28,7 @@ class GroupWrapper
         $this->target = $formGroup->control();
     }
 
-	/**
+    /**
      * @return string
      */
     public function render()
@@ -36,7 +36,7 @@ class GroupWrapper
         return $this->formGroup->render();
     }
 
-	/**
+    /**
      * @param $text
      * @return $this
      */
@@ -46,7 +46,7 @@ class GroupWrapper
         return $this;
     }
 
-	/**
+    /**
      * @return string
      */
     public function __toString()
@@ -54,7 +54,7 @@ class GroupWrapper
         return $this->render();
     }
 
-	/**
+    /**
      * @param string $class
      * @return $this
      */
@@ -64,7 +64,7 @@ class GroupWrapper
         return $this;
     }
 
-	/**
+    /**
      * @param string $class
      * @return $this
      */
@@ -74,7 +74,7 @@ class GroupWrapper
         return $this;
     }
 
-	/**
+    /**
      * @param string $attribute
      * @param string $value
      * @return $this
@@ -85,7 +85,7 @@ class GroupWrapper
         return $this;
     }
 
-	/**
+    /**
      * @param string $class
      * @return $this
      */
@@ -95,7 +95,7 @@ class GroupWrapper
         return $this;
     }
 
-	/**
+    /**
      * @return $this
      */
     public function hideLabel()
@@ -104,7 +104,7 @@ class GroupWrapper
         return $this;
     }
 
-	/**
+    /**
      * @return $this
      */
     public function inline()
@@ -113,7 +113,7 @@ class GroupWrapper
         return $this;
     }
 
-	/**
+    /**
      * @return $this
      */
     public function group()
@@ -122,7 +122,7 @@ class GroupWrapper
         return $this;
     }
 
-	/**
+    /**
      * @return $this
      */
     public function label()
@@ -131,7 +131,7 @@ class GroupWrapper
         return $this;
     }
 
-	/**
+    /**
      * @return $this
      */
     public function control()
@@ -140,7 +140,7 @@ class GroupWrapper
         return $this;
     }
 
-	/**
+    /**
      * @param $method
      * @param $parameters
      * @return $this

--- a/src/AdamWathan/BootForms/Elements/HelpBlock.php
+++ b/src/AdamWathan/BootForms/Elements/HelpBlock.php
@@ -8,12 +8,12 @@ use AdamWathan\Form\Elements\Element;
  */
 class HelpBlock extends Element
 {
-	/**
+    /**
      * @var string
      */
     private $message;
 
-	/**
+    /**
      * HelpBlock constructor.
      * @param $message
      */
@@ -23,7 +23,7 @@ class HelpBlock extends Element
         $this->addClass('help-block');
     }
 
-	/**
+    /**
      * @return string
      */
     public function render()

--- a/src/AdamWathan/BootForms/Elements/HelpBlock.php
+++ b/src/AdamWathan/BootForms/Elements/HelpBlock.php
@@ -2,16 +2,30 @@
 
 use AdamWathan\Form\Elements\Element;
 
+/**
+ * Class HelpBlock
+ * @package AdamWathan\BootForms\Elements
+ */
 class HelpBlock extends Element
 {
+	/**
+     * @var string
+     */
     private $message;
 
+	/**
+     * HelpBlock constructor.
+     * @param $message
+     */
     public function __construct($message)
     {
         $this->message = $message;
         $this->addClass('help-block');
     }
 
+	/**
+     * @return string
+     */
     public function render()
     {
         $html = '<p';

--- a/src/AdamWathan/BootForms/Elements/HorizontalFormGroup.php
+++ b/src/AdamWathan/BootForms/Elements/HorizontalFormGroup.php
@@ -9,12 +9,12 @@ use AdamWathan\Form\Elements\Label;
  */
 class HorizontalFormGroup extends FormGroup
 {
-	/**
+    /**
      * @var array
      */
     protected $controlSizes;
 
-	/**
+    /**
      * HorizontalFormGroup constructor.
      * @param Label $label
      * @param Element $control
@@ -26,7 +26,7 @@ class HorizontalFormGroup extends FormGroup
         $this->controlSizes = $controlSizes;
     }
 
-	/**
+    /**
      * @return string
      */
     public function render()
@@ -45,7 +45,7 @@ class HorizontalFormGroup extends FormGroup
         return $html;
     }
 
-	/**
+    /**
      * @return string
      */
     protected function getControlClass()
@@ -57,7 +57,7 @@ class HorizontalFormGroup extends FormGroup
         return trim($class);
     }
 
-	/**
+    /**
      * @param $method
      * @param $parameters
      * @return $this

--- a/src/AdamWathan/BootForms/Elements/HorizontalFormGroup.php
+++ b/src/AdamWathan/BootForms/Elements/HorizontalFormGroup.php
@@ -3,16 +3,32 @@
 use AdamWathan\Form\Elements\Element;
 use AdamWathan\Form\Elements\Label;
 
+/**
+ * Class HorizontalFormGroup
+ * @package AdamWathan\BootForms\Elements
+ */
 class HorizontalFormGroup extends FormGroup
 {
+	/**
+     * @var array
+     */
     protected $controlSizes;
 
+	/**
+     * HorizontalFormGroup constructor.
+     * @param Label $label
+     * @param Element $control
+     * @param $controlSizes
+     */
     public function __construct(Label $label, Element $control, $controlSizes)
     {
         parent::__construct($label, $control);
         $this->controlSizes = $controlSizes;
     }
 
+	/**
+     * @return string
+     */
     public function render()
     {
         $html = '<div';
@@ -29,6 +45,9 @@ class HorizontalFormGroup extends FormGroup
         return $html;
     }
 
+	/**
+     * @return string
+     */
     protected function getControlClass()
     {
         $class = '';
@@ -38,6 +57,11 @@ class HorizontalFormGroup extends FormGroup
         return trim($class);
     }
 
+	/**
+     * @param $method
+     * @param $parameters
+     * @return $this
+     */
     public function __call($method, $parameters)
     {
         call_user_func_array([$this->control, $method], $parameters);

--- a/src/AdamWathan/BootForms/Elements/InputGroup.php
+++ b/src/AdamWathan/BootForms/Elements/InputGroup.php
@@ -8,17 +8,17 @@ use AdamWathan\Form\Elements\Text;
  */
 class InputGroup extends Text
 {
-	/**
+    /**
      * @var array
      */
     protected $beforeAddon = [];
 
-	/**
+    /**
      * @var array
      */
     protected $afterAddon = [];
 
-	/**
+    /**
      * @param $addon
      * @return $this
      */
@@ -29,7 +29,7 @@ class InputGroup extends Text
         return $this;
     }
 
-	/**
+    /**
      * @param $addon
      * @return $this
      */
@@ -40,7 +40,7 @@ class InputGroup extends Text
         return $this;
     }
 
-	/**
+    /**
      * @param $type
      * @return $this
      */
@@ -50,7 +50,7 @@ class InputGroup extends Text
         return $this;
     }
 
-	/**
+    /**
      * @param array $addons
      * @return string
      */
@@ -67,7 +67,7 @@ class InputGroup extends Text
         return $html;
     }
 
-	/**
+    /**
      * @return string
      */
     public function render()

--- a/src/AdamWathan/BootForms/Elements/InputGroup.php
+++ b/src/AdamWathan/BootForms/Elements/InputGroup.php
@@ -2,12 +2,26 @@
 
 use AdamWathan\Form\Elements\Text;
 
+/**
+ * Class InputGroup
+ * @package AdamWathan\BootForms\Elements
+ */
 class InputGroup extends Text
 {
+	/**
+     * @var array
+     */
     protected $beforeAddon = [];
 
+	/**
+     * @var array
+     */
     protected $afterAddon = [];
 
+	/**
+     * @param $addon
+     * @return $this
+     */
     public function beforeAddon($addon)
     {
         $this->beforeAddon[] = $addon;
@@ -15,6 +29,10 @@ class InputGroup extends Text
         return $this;
     }
 
+	/**
+     * @param $addon
+     * @return $this
+     */
     public function afterAddon($addon)
     {
         $this->afterAddon[] = $addon;
@@ -22,12 +40,20 @@ class InputGroup extends Text
         return $this;
     }
 
+	/**
+     * @param $type
+     * @return $this
+     */
     public function type($type)
     {
         $this->attributes['type'] = $type;
         return $this;
     }
 
+	/**
+     * @param array $addons
+     * @return string
+     */
     protected function renderAddons($addons)
     {
         $html = '';
@@ -41,6 +67,9 @@ class InputGroup extends Text
         return $html;
     }
 
+	/**
+     * @return string
+     */
     public function render()
     {
         $html = '<div class="input-group">';

--- a/src/AdamWathan/BootForms/Elements/OffsetFormGroup.php
+++ b/src/AdamWathan/BootForms/Elements/OffsetFormGroup.php
@@ -1,16 +1,34 @@
 <?php namespace AdamWathan\BootForms\Elements;
 
+/**
+ * Class OffsetFormGroup
+ * @package AdamWathan\BootForms\Elements
+ */
 class OffsetFormGroup
 {
+	/**
+     * @var string
+     */
     protected $control;
+	/**
+     * @var array
+     */
     protected $columnSizes;
 
+	/**
+     * OffsetFormGroup constructor.
+     * @param string $control
+     * @param array $columnSizes
+     */
     public function __construct($control, $columnSizes)
     {
         $this->control = $control;
         $this->columnSizes = $columnSizes;
     }
 
+	/**
+     * @return string
+     */
     public function render()
     {
         $html = '<div class="form-group">';
@@ -23,12 +41,19 @@ class OffsetFormGroup
         return $html;
     }
 
-    public function setColumnSizes($columnSizes)
+	/**
+     * @param array $columnSizes
+     * @return $this
+     */
+    public function setColumnSizes(array $columnSizes)
     {
         $this->columnSizes = $columnSizes;
         return $this;
     }
 
+	/**
+     * @return string
+     */
     protected function getControlClass()
     {
         $class = '';
@@ -38,11 +63,19 @@ class OffsetFormGroup
         return trim($class);
     }
 
+	/**
+     * @return string
+     */
     public function __toString()
     {
         return $this->render();
     }
 
+	/**
+     * @param $method
+     * @param $parameters
+     * @return $this
+     */
     public function __call($method, $parameters)
     {
         call_user_func_array([$this->control, $method], $parameters);

--- a/src/AdamWathan/BootForms/Elements/OffsetFormGroup.php
+++ b/src/AdamWathan/BootForms/Elements/OffsetFormGroup.php
@@ -6,16 +6,16 @@
  */
 class OffsetFormGroup
 {
-	/**
+    /**
      * @var string
      */
     protected $control;
-	/**
+    /**
      * @var array
      */
     protected $columnSizes;
 
-	/**
+    /**
      * OffsetFormGroup constructor.
      * @param string $control
      * @param array $columnSizes
@@ -26,7 +26,7 @@ class OffsetFormGroup
         $this->columnSizes = $columnSizes;
     }
 
-	/**
+    /**
      * @return string
      */
     public function render()
@@ -41,7 +41,7 @@ class OffsetFormGroup
         return $html;
     }
 
-	/**
+    /**
      * @param array $columnSizes
      * @return $this
      */
@@ -51,7 +51,7 @@ class OffsetFormGroup
         return $this;
     }
 
-	/**
+    /**
      * @return string
      */
     protected function getControlClass()
@@ -63,7 +63,7 @@ class OffsetFormGroup
         return trim($class);
     }
 
-	/**
+    /**
      * @return string
      */
     public function __toString()
@@ -71,7 +71,7 @@ class OffsetFormGroup
         return $this->render();
     }
 
-	/**
+    /**
      * @param $method
      * @param $parameters
      * @return $this

--- a/src/AdamWathan/BootForms/HorizontalFormBuilder.php
+++ b/src/AdamWathan/BootForms/HorizontalFormBuilder.php
@@ -97,7 +97,7 @@ class HorizontalFormBuilder extends BasicFormBuilder
         return trim($class);
     }
 
-	/**
+    /**
      * @param $value
      * @param null $name
      * @param string $type
@@ -109,7 +109,7 @@ class HorizontalFormBuilder extends BasicFormBuilder
         return new OffsetFormGroup($button, $this->columnSizes);
     }
 
-	/**
+    /**
      * @param string $value
      * @param string $type
      * @return OffsetFormGroup
@@ -120,7 +120,7 @@ class HorizontalFormBuilder extends BasicFormBuilder
         return new OffsetFormGroup($button, $this->columnSizes);
     }
 
-	/**
+    /**
      * @param $label
      * @param $name
      * @return OffsetFormGroup
@@ -133,7 +133,7 @@ class HorizontalFormBuilder extends BasicFormBuilder
         return new OffsetFormGroup($this->wrap($checkGroup), $this->columnSizes);
     }
 
-	/**
+    /**
      * @param $label
      * @param $name
      * @param $control
@@ -153,7 +153,7 @@ class HorizontalFormBuilder extends BasicFormBuilder
         return $checkGroup;
     }
 
-	/**
+    /**
      * @param $label
      * @param $name
      * @param null $value
@@ -171,7 +171,7 @@ class HorizontalFormBuilder extends BasicFormBuilder
         return new OffsetFormGroup($this->wrap($checkGroup), $this->columnSizes);
     }
 
-	/**
+    /**
      * @param $label
      * @param $name
      * @param null $value
@@ -197,7 +197,7 @@ class HorizontalFormBuilder extends BasicFormBuilder
         return $formGroup;
     }
 
-	/**
+    /**
      * @param $method
      * @param $parameters
      * @return mixed

--- a/src/AdamWathan/BootForms/HorizontalFormBuilder.php
+++ b/src/AdamWathan/BootForms/HorizontalFormBuilder.php
@@ -6,29 +6,54 @@ use AdamWathan\BootForms\Elements\HorizontalFormGroup;
 use AdamWathan\BootForms\Elements\OffsetFormGroup;
 use AdamWathan\Form\FormBuilder;
 
+/**
+ * Class HorizontalFormBuilder
+ * @package AdamWathan\BootForms
+ */
 class HorizontalFormBuilder extends BasicFormBuilder
 {
     protected $columnSizes;
 
+    /**
+     * @var FormBuilder
+     */
     protected $builder;
 
+    /**
+     * HorizontalFormBuilder constructor.
+     * @param FormBuilder $builder
+     * @param array $columnSizes
+     */
     public function __construct(FormBuilder $builder, $columnSizes = ['lg' => [2, 10]])
     {
-        $this->builder = $builder;
+        parent::__construct($builder);
         $this->columnSizes = $columnSizes;
     }
 
+    /**
+     * @param $columnSizes
+     * @return $this
+     */
     public function setColumnSizes($columnSizes)
     {
         $this->columnSizes = $columnSizes;
         return $this;
     }
 
+    /**
+     * @return \AdamWathan\Form\Elements\FormOpen
+     */
     public function open()
     {
         return $this->builder->open()->addClass('form-horizontal');
     }
 
+    /**
+     * @param $label
+     * @param $name
+     * @param $control
+     * @return Elements\GroupWrapper
+     */
     protected function formGroup($label, $name, $control)
     {
         $label = $this->builder->label($label, $name)
@@ -48,6 +73,9 @@ class HorizontalFormBuilder extends BasicFormBuilder
         return $this->wrap($formGroup);
     }
 
+    /**
+     * @return array
+     */
     protected function getControlSizes()
     {
         $controlSizes = [];
@@ -57,6 +85,9 @@ class HorizontalFormBuilder extends BasicFormBuilder
         return $controlSizes;
     }
 
+    /**
+     * @return string
+     */
     protected function getLabelClass()
     {
         $class = '';
@@ -66,18 +97,34 @@ class HorizontalFormBuilder extends BasicFormBuilder
         return trim($class);
     }
 
+	/**
+     * @param $value
+     * @param null $name
+     * @param string $type
+     * @return OffsetFormGroup
+     */
     public function button($value, $name = null, $type = "btn-default")
     {
         $button = $this->builder->button($value, $name)->addClass('btn')->addClass($type);
         return new OffsetFormGroup($button, $this->columnSizes);
     }
 
+	/**
+     * @param string $value
+     * @param string $type
+     * @return OffsetFormGroup
+     */
     public function submit($value = "Submit", $type = "btn-default")
     {
         $button = $this->builder->submit($value)->addClass('btn')->addClass($type);
         return new OffsetFormGroup($button, $this->columnSizes);
     }
 
+	/**
+     * @param $label
+     * @param $name
+     * @return OffsetFormGroup
+     */
     public function checkbox($label, $name)
     {
         $control = $this->builder->checkbox($name);
@@ -86,6 +133,12 @@ class HorizontalFormBuilder extends BasicFormBuilder
         return new OffsetFormGroup($this->wrap($checkGroup), $this->columnSizes);
     }
 
+	/**
+     * @param $label
+     * @param $name
+     * @param $control
+     * @return CheckGroup
+     */
     protected function checkGroup($label, $name, $control)
     {
         $label = $this->builder->label($label, $name)->after($control);
@@ -100,6 +153,12 @@ class HorizontalFormBuilder extends BasicFormBuilder
         return $checkGroup;
     }
 
+	/**
+     * @param $label
+     * @param $name
+     * @param null $value
+     * @return OffsetFormGroup
+     */
     public function radio($label, $name, $value = null)
     {
         if (is_null($value)) {
@@ -112,6 +171,12 @@ class HorizontalFormBuilder extends BasicFormBuilder
         return new OffsetFormGroup($this->wrap($checkGroup), $this->columnSizes);
     }
 
+	/**
+     * @param $label
+     * @param $name
+     * @param null $value
+     * @return HorizontalFormGroup
+     */
     public function file($label, $name, $value = null)
     {
         $control = $this->builder->file($name)->value($value);
@@ -132,6 +197,11 @@ class HorizontalFormBuilder extends BasicFormBuilder
         return $formGroup;
     }
 
+	/**
+     * @param $method
+     * @param $parameters
+     * @return mixed
+     */
     public function __call($method, $parameters)
     {
         return call_user_func_array([$this->builder, $method], $parameters);


### PR DESCRIPTION
Hi,

This is a pretty nifty form builder I am using on a couple of my projects, so I thought why not update it to:

- Support provider & facade auto-discovery for Laravel 5.5 & above
- Merge some PHPDocs from another pull request #110 (which make life real easier when working in an IDE such as PHPStorm, IMO)